### PR TITLE
Fix for Issue #4, Inline html in slack output.

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -147,8 +147,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
             Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
             if (result == Result.SUCCESS && previousResult == Result.FAILURE) return "Back to normal";
             if (result == Result.SUCCESS) return "Success";
-            if (result == Result.FAILURE) return "<b>FAILURE</b>";
-            if (result == Result.ABORTED) return "ABORTED";
+            if (result == Result.FAILURE) return "Failure";
+            if (result == Result.ABORTED) return "Aborted";
             if (result == Result.NOT_BUILT) return "Not built";
             if (result == Result.UNSTABLE) return "Unstable";
             return "Unknown";


### PR DESCRIPTION
Removed HTML tags in slack status messages and normalised status strings (UPPERCASE -> Normal)
