### PR TITLE
Change to .getPreviousCompletedBuild() to allow for concurrency

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -60,7 +60,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         AbstractProject<?, ?> project = r.getProject();
         SlackNotifier.SlackJobProperty jobProperty = project.getProperty(SlackNotifier.SlackJobProperty.class);
         Result result = r.getResult();
-        AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousBuild();
+        AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousCompletedBuild();
         Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
         if ((result == Result.ABORTED && jobProperty.getNotifyAborted())
                 || (result == Result.FAILURE && jobProperty.getNotifyFailure())
@@ -143,7 +143,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 return "Starting...";
             }
             Result result = r.getResult();
-            Run previousBuild = r.getProject().getLastBuild().getPreviousBuild();
+            Run previousBuild = r.getProject().getLastBuild().getPreviousCompletedBuild();
             Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
             if (result == Result.SUCCESS && previousResult == Result.FAILURE) return "Back to normal";
             if (result == Result.SUCCESS) return "Success";


### PR DESCRIPTION
Jenkins changed getPreviousBuild() to halt jobs if a previous
build hasn't finished, meaning jobs of variable runtime end up
being serialized:

https://issues.jenkins-ci.org/browse/JENKINS-9913?focusedCommentId=184188&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-184188

This change switches to the latest completed build, allowing
this plugin to work with jobs of variable length.
